### PR TITLE
Fix tests and deprecation warnings

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,0 +1,103 @@
+# Deprecations and migration notes
+
+This project emits a few deprecation warnings during the test suite. Below are the messages, why they occur, and how to update your code. These are safe cleanups you can do in your own applications.
+
+## Ethon: Easy#supports_zlib? is deprecated
+
+Message:
+
+> Ethon: Easy#supports_zlib? is deprecated and will be removed, please use Easy#.
+
+Cause:
+- Calling the instance method `Ethon::Easy#supports_zlib?`.
+
+Fix:
+- Use the class method instead.
+
+Before:
+```ruby
+easy = Ethon::Easy.new
+zlib_supported = easy.supports_zlib?
+```
+After:
+```ruby
+zlib_supported = Ethon::Easy.supports_zlib?
+```
+
+## ETHON: It is no longer necessary to call Easy#prepare
+
+Message:
+
+> ETHON: It is no longer necessary to call Easy#prepare. It's going to be removed
+
+Cause:
+- Explicitly invoking `Ethon::Easy#prepare`.
+
+Fix:
+- Remove calls to `prepare`. Initialization and request setup happen automatically via `http_request` and related APIs.
+
+Before:
+```ruby
+easy = Ethon::Easy.new
+# easy.prepare  # remove this
+```
+After:
+```ruby
+easy = Ethon::Easy.new
+# no explicit prepare needed
+```
+
+## ETHON: It is no longer necessary to call Multi#prepare
+
+Message:
+
+> ETHON: It is no longer necessay to call Multi#prepare. Its going to be removed
+
+Cause:
+- Explicitly invoking `Ethon::Multi#prepare`.
+
+Fix:
+- Remove calls to `prepare`. Use `multi.add(easy)` and `multi.perform` directly.
+
+Before:
+```ruby
+multi = Ethon::Multi.new
+# multi.prepare  # remove this
+```
+After:
+```ruby
+multi = Ethon::Multi.new
+# no explicit prepare needed
+```
+
+## Ethon: Easy#to_hash is deprecated
+
+Message:
+
+> Ethon: Easy#to_hash is deprecated and will be removed, please use #mirror.
+
+Cause:
+- Invoking `Ethon::Easy#to_hash` on an `Easy` instance.
+
+Fix:
+- Use `Ethon::Easy#mirror` to obtain a `Mirror` and then call `#to_hash` if needed, or directly access data via methods on `Mirror`.
+
+Before:
+```ruby
+easy = Ethon::Easy.new
+# ... perform request ...
+result = easy.to_hash
+```
+After:
+```ruby
+easy = Ethon::Easy.new
+# ... perform request ...
+result = easy.mirror.to_hash
+```
+
+---
+
+Notes:
+- Some specs intentionally exercise deprecated APIs to ensure warnings are emitted and behavior remains compatible while the deprecation period is active.
+- For Ruby 3.x environments, `webrick` is added in the development/test group to provide the Rack server used in tests.
+- Sinatra is constrained to `~> 2.2` to ensure compatibility with the test helper server implemented under `spec/support/server.rb`.

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 group :development, :test do
   gem "rspec", "~> 3.4"
 
-  gem "sinatra"
+  gem "sinatra", "~> 2.2"
 
   if Gem.ruby_version < Gem::Version.new("2.0.0")
     gem "json", "< 2"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ In the modern world, Ethon is a very basic libcurl wrapper using ffi.
 * [Documentation](http://rubydoc.info/github/typhoeus/ethon/frames/Ethon)
 * [Website](http://typhoeus.github.com/)
 * [Mailing list](http://groups.google.com/group/typhoeus)
+* [Deprecations and migration notes](DEPRECATIONS.md)
 
 ## Installation
 


### PR DESCRIPTION
Add Sinatra version constraint and document Ethon deprecation warnings.

The Sinatra constraint (`~> 2.2`) is necessary for tests to pass on modern Ruby versions. The deprecation documentation (`DEPRECATIONS.md`) provides guidance on addressing warnings emitted by the test suite, prioritizing low-hanging fruit.

---
<a href="https://cursor.com/background-agent?bcId=bc-adccfb9e-25cd-4441-9f9c-cd873e2a8e25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-adccfb9e-25cd-4441-9f9c-cd873e2a8e25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

