### PR TITLE
Use one Sinatra test stack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,17 +6,11 @@ gem "rake"
 
 group :development, :test do
   gem "rspec", "~> 3.4"
-  
-  if Gem.ruby_version < Gem::Version.new("3.0.0")
-    gem "sinatra", "~> 2.2"
-  else
-    gem "sinatra"
-  end
-  
+
+  gem "sinatra", "~> 4.2"
   gem "rackup"
   gem "json"
   gem "mime-types", "~> 1.18"
-  gem "mustermann"
   gem "webrick"
 end
 


### PR DESCRIPTION
## Summary

- use Sinatra 4.2 for every supported Ruby
- let Sinatra select its compatible Mustermann dependency instead of declaring Mustermann directly
- remove the Ruby-version conditional from the test Gemfile

This leaves one Rack 3 / Sinatra 4 test stack across Ruby 2.7.8 through Ruby 4.0.

## Verification

- Ruby 2.7.8 / Bundler 2.4.22 / libcurl 7.74.0: 579 examples, 0 failures, 2 pending
- Ruby 4.0.6 / Bundler 4.0.16 / libcurl 8.14.1: 579 examples, 0 failures, 2 pending
- both resolve Sinatra 4.2.1, Rack 3.2.7, and Mustermann 3.1.1

## Stack

This is intentionally based on the Ruby 2.7.8 floor branch so this remains a one-file dependency PR. Retarget it to `master` after the floor pull request merges.