### PR TITLE
Refresh the CI test workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,14 +16,16 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}-latest
+    env:
+      BUNDLE_WITHOUT: perf
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby-version: ['2.7.8', '3.0', '3.1', '3.2', '3.3', '3.4', head, debug, truffleruby]
-    continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
+        ruby-version: ['2.7.8', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0', head, debug, truffleruby]
+    continue-on-error: ${{ matrix.ruby-version == 'head' || matrix.ruby-version == 'debug' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Install libcurl header
       run: |
         if ${{ matrix.os == 'macos' }}


### PR DESCRIPTION
## Summary

- skip the benchmark-only `perf` Bundler group in test jobs
- add blocking Ruby 4.0 coverage
- make only `head` and `debug` allowed failures using the correct matrix key
- update checkout from v3 to v6

Skipping `perf` keeps Patron and Curb from making ordinary test installation depend on unrelated native extensions.

## Verification

- `actionlint` 1.7.12 passes
- matrix expands to 20 jobs across two operating systems
- 16 jobs are blocking; only head and debug are allowed failures
- Bundler maps `BUNDLE_WITHOUT` to the perf group

## Stack

This is intentionally based on the Sinatra test-stack branch so the pull request remains workflow-only. Retarget it to `master` after the preceding pull requests merge.